### PR TITLE
Reduce bundle size (5x), improve tests, and wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ npm install suspendable
 
 ## API
 
-- [`lazyResource`](#lazyResource)
-- [`Resource`](#Resource)
-- [`ResourceOptions`](#ResourceOptions)
-- [`clearResourceErrors`](#clearResourceErrors)
-- [`lazyComponent`](#lazyComponent)
-- [`preloadLazyComponent`](#preloadLazyComponent)
-- [`clearLazyComponentError`](#clearLazyComponentError)
+- [`lazyResource`](#lazyresource)
+- [`Resource`](#resource)
+- [`ResourceOptions`](#resourceoptions)
+- [`clearResourceErrors`](#clearresourceerrors)
+- [`lazyComponent`](#lazycomponent)
+- [`preloadLazyComponent`](#preloadlazycomponent)
+- [`clearLazyComponentError`](#clearlazycomponenterror)
 
 ### `lazyResource`
 
@@ -40,11 +40,11 @@ lazyResource<T>(loader: () => Promise<T>, options?: ResourceOptions): Resource<T
 
 - `loader` is the loader function to load a resource of type `T`. This is a regular function that returns a promise.
 
-- `options?: ResourceOptions` are the [resource options](#ResourceOptions).
+- `options?: ResourceOptions` are the [resource options](#resourceoptions).
 
 **Return value**
 
-- `Resource<T>` a [resource](#Resource) of type `T`.
+- `Resource<T>` a [resource](#resource) of type `T`.
 
 **Description**
 
@@ -114,7 +114,7 @@ lazyComponent<P>(loader: () => Promise<{ default: ComponentType<P> }>, options?:
 
 - `loader` is the loader function to load a React component. This is a function that returns a dynamic import. The component should be the default export of the module that is dynamically imported.
 
-- `options?: ResourceOptions` are the [resource options](#ResourceOptions).
+- `options?: ResourceOptions` are the [resource options](#resourceoptions).
 
 **Return value**
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ lazyResource<T>(loader: () => Promise<T>, options?: ResourceOptions): Resource<T
 
 **Description**
 
-`lazyResource` is used to create a lazy resource. It's lazy because it will not start loading the resource immediately. Instead, it will start loading it only when the `load` method is called. The resource can be read at any point inside a React component - if it has not loaded at the time it is called, the component will suspend.
+`lazyResource` is used to create a lazy resource. It's lazy because it will not start loading the resource immediately. Instead, it will start loading it only when the `load` method is called. The resource can be read at any point inside a React component - if it has not loaded at the time it is read, the component will suspend.
 
 **Example**
 
@@ -79,7 +79,7 @@ interface Resource<T> {
 
 - `load: () => Promise<T>` begins loading the resource by calling the provided loader function. This method is idempotent - calling it after the first time has no effect. However, If the resource fails to load and `Resource#clearError()` is called (or `clearResourceErrors`), then calling this method will again begin loading the resource.
 
-- `read: () => T` returns the loaded resource. If the resource is still loading when this method is called, it will throw the resource promise, which will make the React component suspend and show the fallback of the nearest `<Suspense>` ancestor. If the resource failed to load, then this method will throw the error with which the promise rejected, causing the nearest error boundary ancestor to be hit. This method must be called inside a React component and it can only be called after the resource started loading with `Resource#load()`.
+- `read: () => T` returns the loaded resource. If the resource is still loading when this method is called, it will throw the resource promise, which will make the React component suspend and show the fallback of the nearest `<Suspense>` ancestor. If the resource failed to load, then this method will throw the error with which the promise rejected, causing the fallback of the nearest error boundary ancestor to be shown, if any. This method must be called inside a React component and it can only be called after the resource started loading with `Resource#load()`.
 
 ### `ResourceOptions`
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "size-limit": "^4.9.0",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.3",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "circumspect": "^0.1.1"
   },
   "peerDependencies": {
-    "react": ">=16.6"
+    "react": ">=16.6.0"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.9.0",
@@ -72,11 +72,11 @@
   "size-limit": [
     {
       "path": "dist/suspendable.cjs.production.min.js",
-      "limit": "3 KB"
+      "limit": "600 B"
     },
     {
       "path": "dist/suspendable.esm.js",
-      "limit": "3 KB"
+      "limit": "600 B"
     }
   ]
 }

--- a/src/lazyResource/index.test.ts
+++ b/src/lazyResource/index.test.ts
@@ -376,23 +376,45 @@ describe('lazyResource', () => {
 
 describe('clearResourceErrors', () => {
   it('clears resource errors', async () => {
-    expect.assertions(3);
+    expect.assertions(6);
 
-    const { loader, error, result } = anErrorThenSuccessLoader();
+    const {
+      loader: loader1,
+      error: error1,
+      result: result1,
+    } = anErrorThenSuccessLoader();
 
-    const resource = lazyResource(loader);
+    const {
+      loader: loader2,
+      error: error2,
+      result: result2,
+    } = anErrorThenSuccessLoader();
+
+    const resource1 = lazyResource(loader1);
+    const resource2 = lazyResource(loader2);
 
     try {
-      await resource.load();
+      await resource1.load();
     } catch (err) {
-      expect(err).toBe(error);
+      expect(err).toBe(error1);
+    }
+
+    try {
+      await resource2.load();
+    } catch (err) {
+      expect(err).toBe(error2);
     }
 
     clearResourceErrors();
 
-    const value = await resource.load();
+    const value1 = await resource1.load();
 
-    expect(value).toBe(result);
-    expect(loader).toHaveBeenCalledTimes(2);
+    expect(value1).toBe(result1);
+    expect(loader1).toHaveBeenCalledTimes(2);
+
+    const value2 = await resource2.load();
+
+    expect(value2).toBe(result2);
+    expect(loader2).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lazyResource/index.ts
+++ b/src/lazyResource/index.ts
@@ -14,7 +14,7 @@ const resourcesWithError = new Set<Resource<unknown>>();
  * Creates a lazy resource. It's lazy because it will not start loading the
  * resource immediately. Instead, it will start loading it only when the `load`
  * method is called. The resource can be read at any point inside a React
- * component - if it has not loaded at the time it is called, the component
+ * component - if it has not loaded at the time it is read, the component
  * will suspend.
  * @param loader the loader function to load a resource of type `T`. This is a
  *    regular function that returns a promise.

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,10 +26,10 @@ export interface Resource<T> {
    * method is called, it will throw the resource promise, which will make the
    * React component suspend and show the fallback of the nearest `<Suspense>`
    * ancestor. If the resource failed to load, then this method will throw the
-   * error with which the promise rejected, causing the nearest error boundary
-   * ancestor to be hit. This method must be called inside a React component
-   * and it can only be called after the resource started loading with
-   * `Resource#load()`.
+   * error with which the promise rejected, causing the fallback of nearest
+   * error boundary ancestor to be shown, if any. This method must be called
+   * inside a React component and it can only be called after the resource
+   * started loading with `Resource#load()`.
    */
   read: () => T;
 }

--- a/src/utils/promise/autoRetryOnRejection/index.ts
+++ b/src/utils/promise/autoRetryOnRejection/index.ts
@@ -4,6 +4,14 @@ interface Options {
   timeoutMs?: number;
 }
 
+const autoRetryOnRejectionRec = <T extends any>(
+  fn: () => Promise<T>,
+  options: Required<Options>,
+): Promise<T> =>
+  fn().catch(() =>
+    wait(options.timeoutMs).then(() => autoRetryOnRejectionRec(fn, options)),
+  );
+
 /**
  * Given a function that returns a promise, keeps calling it until the returned
  * promise resolves, returning the result. If the promise rejects, waits
@@ -11,19 +19,11 @@ interface Options {
  * @param fn The function that returns a promise.
  * @param options Options that can be used to adjust the retry timeout (default 3000).
  */
-export const autoRetryOnRejection = async <T extends any>(
+export const autoRetryOnRejection = <T extends any>(
   fn: () => Promise<T>,
   options: Options = {},
 ) => {
   const { timeoutMs = 3000 } = options;
 
-  while (true) {
-    try {
-      const result = await fn();
-
-      return result;
-    } catch {
-      await wait(timeoutMs);
-    }
-  }
+  return autoRetryOnRejectionRec(fn, { timeoutMs });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8503,10 +8503,10 @@ typescript@^3.7.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Changes

- Update `clearResourceErrors` test to create 2 separate lazy resources.
- Improve wording in README and documentation comments.
- Fix section link anchors in README.
- Reduce bundle size by optimizing `autoRetryOnRejection`.
    Reduced the bundle size from almost `3 KB` to less than `600 B` (5x reduction) by making `autoRetryOnRejection` a regular function rather than async function. Using an async function causes TypeScript to emit helper code, increasing the bundle size by about `2.4 KB`. Now, we instead just use promise methods and recursion to achieve the same behavior we had with an async function.
- Upgrade TypeScript to 4.1.3.